### PR TITLE
Added llmart vision example

### DIFF
--- a/examples/vision/README.md
+++ b/examples/vision/README.md
@@ -1,0 +1,14 @@
+# Vision Example
+
+This example demonstrates how to use the `LLMart` library for performing adversarial attacks on vision models like `meta-llama/Llama-3.2-11B-Vision`. The script `main.py` provides a comprehensive example of how to set up the `LLMart` library for vision models.
+
+## Installation
+Install llmart and download/navigate to this folder. Run `pip install -r requirements.txt`.
+
+## Running
+
+To run the example, execute the following command:
+
+```bash
+python main.py
+```

--- a/examples/vision/main.py
+++ b/examples/vision/main.py
@@ -1,0 +1,183 @@
+#
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# type: ignore
+
+import fire  # type: ignore[reportMissingImports]
+import torch
+import requests
+from tqdm import tqdm
+from PIL import Image
+
+from transformers import MllamaForConditionalGeneration, AutoProcessor
+
+from llmart import (
+    TaggedTokenizer,
+    GreedyCoordinateGradient,
+    AttackPrompt,
+    MaskCompletion,
+    AdversarialAttack,
+)
+from llmart.attack import make_closure
+from llmart.losses import CausalLMLoss
+from model_position import AdversarialBlockShift
+
+torch.manual_seed(2025)
+
+def attack(
+    suffix=10,
+    n_swaps=512,
+    n_tokens=2,
+    num_steps=500,
+    per_device_bs=64,
+    position_cadence=5,
+):
+    # Define user input and image
+    user_input = "If I had to write a haiku for this one"
+
+    user_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/0052a70beed5bf71b92610a43a52df6d286cd5f3/diffusers/rabbit.jpg"
+    user_image = Image.open(requests.get(user_url, stream=True).raw)
+
+    induced_response = "Self-attention is not supported in PyTorch.<|eot_id|>"
+
+    # Get HF model and processor (contains tokenizer)
+    model_id = "meta-llama/Llama-3.2-11B-Vision"
+    model = MllamaForConditionalGeneration.from_pretrained(
+        model_id,
+        device_map="auto",
+        torch_dtype="bfloat16",
+    )
+    processor = AutoProcessor.from_pretrained(model_id)
+
+    # Get processor.tokenizer and wrap it
+    tokenizer = processor.tokenizer
+    tokenizer.clean_up_tokenization_spaces = False
+    tokenizer.pad_token = tokenizer.pad_token or tokenizer.eos_token
+
+    # Create transforms that inject markers into prompts
+    add_attack = AttackPrompt(suffix=suffix)
+    force_response = MaskCompletion(replace_with=induced_response)
+
+    # Make tokenizer aware of attack marker tokens
+    wrapped_tokenizer = TaggedTokenizer(
+        tokenizer, tags=add_attack.tags + force_response.tags
+    )
+    # Update processor with wrapped tokenizer
+    processor.tokenizer = wrapped_tokenizer
+
+    # Create and tokenize conversation
+    conversation = [
+        dict(role="user", content=add_attack(user_input)),
+        dict(role="assistant", content=force_response("")),
+    ]
+
+    # Prepare Inputs
+    processor.chat_template = conversation
+    text_inputs = processor(text=user_input, return_tensors="pt")
+    image_inputs = processor(images=user_image, return_tensors="pt")
+    inputs = {**text_inputs, **image_inputs}
+
+    # Convert inputs to tensors
+    input_ids = inputs["input_ids"].to(model.device)
+    attention_mask = inputs["attention_mask"].to(model.device)
+    pixel_values = inputs["pixel_values"].to(model.device)
+
+    ''' TODO - Able to convert processor from AutoProcessor class into wrapped_tokenizer, and getting the `inputs` dictionary containing both text_inputs and image_inputs, but somehow the attack does not proceed further due to the following error:
+    torch.cat(): expected a non-empty list of Tensors
+    File "/home/adarshan/LLMart/src/llmart/model.py", line 98, in _create_parameters
+        param = torch.nn.Parameter(torch.cat(list(params.values()), dim=0))
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/home/adarshan/LLMart/src/llmart/model.py", line 52, in __init__
+        self.param, self.slices = self._create_parameters(attacks)
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/home/adarshan/LLMart/examples/vision/main.py", line 84, in attack
+        token_attack = AdversarialAttack(inputs, model.get_input_embeddings()).to(
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    File "/home/adarshan/LLMart/examples/vision/main.py", line 162, in <module>
+        fire.Fire(attack)
+    RuntimeError: torch.cat(): expected a non-empty list of Tensors
+
+    NOTE - Due to less time and lack of understanding of the code, I am unable to debug the error, so submitting the partial code as it is.
+    '''
+    # Get the adversarial token and block shift attacks
+    token_attack = AdversarialAttack(inputs, model.get_input_embeddings()).to(
+        model.device
+    )
+
+    position_attack = AdversarialBlockShift(
+        inputs,
+        embedding=model.get_input_embeddings(),
+    ).to(model.device)
+
+    # Apply the two attacks simultaneously
+    attack = torch.nn.Sequential(token_attack, position_attack)
+
+    # Optimizers
+    optimizer_tokens = GreedyCoordinateGradient(
+        token_attack.parameters(),
+        ignored_values=wrapped_tokenizer.bad_token_ids,  # Consider only ASCII solutions
+        n_tokens=n_tokens,
+        n_swaps=n_swaps,
+    )
+    optimizer_position = GreedyCoordinateGradient(
+        position_attack.parameters(),
+        n_tokens=1,
+    )
+
+    # Get closure to pass to discrete optimizer
+    closure, closure_inputs = make_closure(
+        attack,
+        model,
+        loss_fn=CausalLMLoss(),
+        is_valid_input=wrapped_tokenizer.reencodes,
+        batch_size=per_device_bs,
+        use_kv_cache=False,  # NOTE: KV caching is incompatible with optimizable position
+    )
+
+    # For each step
+    for step in (pbar := tqdm(range(num_steps))):
+        optimizer_tokens.zero_grad()
+        optimizer_position.zero_grad()
+
+        # Apply the latest attack
+        adv_inputs = attack(inputs)
+        outputs = model(
+            inputs_embeds=adv_inputs["inputs_embeds"],
+            labels=adv_inputs["labels"],
+            attention_mask=adv_inputs["attention_mask"],
+        )
+        loss = outputs["loss"]
+        pbar.set_postfix({"loss": loss.item()})
+
+        # Backprop
+        loss.backward()
+
+        # Optimizer
+        with torch.no_grad():
+            # Update the closure inputs
+            closure_inputs.update(inputs)
+            # Alternating optimization
+            if (step + 1) % position_cadence == 0:
+                optimizer_position.step(closure)
+            else:
+                optimizer_tokens.step(closure)
+
+        if step == 0 or (step + 1) % 10 == 0:
+            # Deterministically generate a response using the adversarial prompt
+            prompt_end = adv_inputs["response_mask"].nonzero()[0, -1]
+            result = model.generate(
+                inputs=adv_inputs["input_ids"][:, :prompt_end],
+                attention_mask=adv_inputs["attention_mask"][:, :prompt_end],
+                do_sample=False,
+                temperature=None,
+                top_p=None,
+                pad_token_id=wrapped_tokenizer.pad_token_id,
+            )
+            result = wrapped_tokenizer.decode(result[0])
+            print(f"{result = }")
+
+
+if __name__ == "__main__":
+    fire.Fire(attack)

--- a/examples/vision/model_position.py
+++ b/examples/vision/model_position.py
@@ -1,0 +1,219 @@
+#
+# Copyright (C) 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import torch
+import torch.nn.functional as F
+from typing import Any
+from collections.abc import Mapping
+
+
+class AdversarialBlockShift(torch.nn.Module):
+    """Implements adversarial token block position shifting in user-controllable inputs.
+
+    Uses convolution-based shifting of the token embeddings to preserve gradients.
+
+    Args:
+        attacks: Dictionary containing attack masks and response masks
+        embedding: Token embedding dictionary
+        extra_tokens: List of [preamble, postamble] token counts that are not modifiable by the user.
+
+    """
+
+    def __init__(
+        self,
+        attacks: Mapping[str, Any],
+        embedding: torch.nn.Module,
+        # FIXME: This is a Llama 3 workaround for currently not having a "front-end" user mask
+        extra_tokens: list[int] = [5, 5],  # [preamble, postamble]
+    ):
+        super().__init__()
+
+        if not isinstance(embedding, torch.nn.Embedding):
+            raise ValueError("embedding must be an nn.Embedding")
+        self._embedding = [embedding]
+        self.extra_tokens = extra_tokens
+
+        # Get the allowable block mask and maximum block shifts in both directions
+        (
+            self.mask_name,
+            self.frontend_user_mask,
+            self.max_left_shift,
+            self.max_right_shift,
+        ) = self._get_move_mask_and_shifts(attacks, extra_tokens)
+
+        # Instantiate the parameters as an asymmetric kernel, and padding for it
+        self.param = self._create_parameters()
+
+    def _get_move_mask_and_shifts(
+        self, attack_init: Mapping[str, Any], extra_tokens: list[int]
+    ) -> tuple[str, torch.Tensor, int, int]:
+        mask_name = self._find_attack_key(attack_init)
+        # Get the position of the original suffix in the user-controllable (front-end) tokens
+        # NOTE: The mask is intended to only cover the latest (in a multi-turn conversation)
+        # user-controllable message
+        response_begin = torch.where(attack_init["response_mask"])[-1][0]
+        frontend_user_mask = attack_init["response_mask"].logical_not()
+        frontend_user_mask[..., : extra_tokens[0]] = False
+        frontend_user_mask[..., response_begin - extra_tokens[1] :] = False
+        block_mask = attack_init[mask_name]
+        move_mask = torch.cat(
+            [
+                b_mask[fe_mask]
+                for b_mask, fe_mask in zip(block_mask, frontend_user_mask)
+            ],
+            dim=0,
+        )
+
+        # Compute the maximum realizable shifts
+        max_left_shift = int(torch.where(move_mask)[-1][0].item())
+        max_right_shift = int(
+            len(move_mask) - (torch.where(move_mask)[-1][-1] + 1).item()
+        )
+
+        return mask_name, frontend_user_mask, max_left_shift, max_right_shift
+
+    def _find_attack_key(self, attack_init: Mapping[str, Any]):
+        # Store the attack mask name
+        found, mask_name = False, None
+        for key in attack_init:
+            if key in ["prefix_mask", "suffix_mask"] and found:
+                raise ValueError(
+                    "Optimizing adversarial block position doesn't currently support simultaneous prefix and suffix!"
+                )
+
+            if key in ["prefix_mask", "suffix_mask"]:
+                found = True
+                mask_name = key
+
+        if not mask_name:
+            raise ValueError(
+                "Optimizing adversarial block position requires attack=suffix or attack=prefix!"
+            )
+
+        return mask_name
+
+    def _create_parameters(self):
+        # One-hot convolutional kernel that shifts the attack mask
+        # Interpretation **after** padding and reflection:
+        # (0, 0, ..., 0, 1, 0, ..., 0, 0) (1 in center) -> adversarial block stays in place
+        # (0, 0, ..., 1, 0, 0, ..., 0, 0) -> adversarial block shifts one position to the LEFT
+        # (0, 0, ..., 0, 0, 1, ..., 0, 0) -> adversarial block shifts one position to the RIGHT
+        param = torch.nn.Parameter(
+            torch.zeros(
+                1,
+                self.max_left_shift + self.max_right_shift + 1,
+                dtype=torch.float32,
+            )
+        )
+
+        # Initialize to centered Dirac impulse (after padding)
+        param.data[0, self.max_left_shift] = 1.0
+
+        # Compute amount of padding for the differentiable kernel
+        self.left_pad = int(max(0, self.max_right_shift - self.max_left_shift))
+        self.right_pad = int(max(0, self.max_left_shift - self.max_right_shift))
+        self.padded_kernel_size = 2 * max(self.max_left_shift, self.max_right_shift) + 1
+
+        return param
+
+    @property
+    def embedding(self):
+        return self._embedding[0]
+
+    def _embed(self, input_ids):
+        return self.embedding(input_ids.to(device=self.embedding.weight.device))
+
+    def forward(self, inputs):
+        """Shifts adversarial blocks within the sequence using current parameters.
+
+        Args:
+            inputs: Dictionary containing 'input_ids', user mask, and optionally 'inputs_embeds'
+
+        Returns:
+            Dictionary with modified 'input_ids' and 'inputs_embeds'
+        """
+        # Re-use token embeddings were already computed
+        batch_inputs_embeds = inputs.pop(
+            "inputs_embeds", self._embed(inputs["input_ids"])
+        )
+
+        output_embeds, output_ids = [], []
+        for attack_mask, inputs_embeds, input_ids, frontend_mask in zip(
+            inputs[self.mask_name],
+            batch_inputs_embeds,
+            inputs["input_ids"],
+            self.frontend_user_mask,
+        ):
+            # Get the padded kernel and reflect it
+            # https://discuss.pytorch.org/t/why-are-pytorch-convolutions-implemented-as-cross-correlations/115010
+            padded_kernel = (
+                F.pad(self.param, pad=(self.left_pad, self.right_pad, 0, 0))
+                .flip(dims=(-1,))
+                .to(inputs_embeds.dtype)
+            )
+
+            # Extract the embeddings for the frontend user and everything else
+            other_embeds = inputs_embeds[frontend_mask.logical_not()]
+            frontend_user_embeds = inputs_embeds[frontend_mask]
+
+            # Filter by treating the embedding dimension as "channels"
+            # Will cause a warning https://github.com/pytorch/pytorch/issues/47163 with DDP
+            new_frontend_user_embeds = (
+                F.conv1d(
+                    frontend_user_embeds.T[None, ...],
+                    # Same filter is applied to all "channels"
+                    padded_kernel[None, ...].expand(
+                        frontend_user_embeds.shape[-1], -1, -1
+                    ),
+                    groups=frontend_user_embeds.shape[-1],
+                    padding="same",
+                )
+                .squeeze()
+                .T
+            )
+
+            # Assemble embeddings back together
+            embeddings = torch.cat(
+                [
+                    other_embeds[: self.extra_tokens[0]],
+                    new_frontend_user_embeds,
+                    other_embeds[self.extra_tokens[1] :],
+                ],
+                dim=0,
+            )
+            output_embeds.append(embeddings)
+
+            # Modify the other inputs (non-differentiably)
+            with torch.no_grad():
+                current_start = torch.where(
+                    attack_mask.isclose(torch.ones_like(attack_mask))
+                )[0][0].item()
+                mask_shift = (
+                    padded_kernel.shape[-1] // 2
+                    - torch.where(padded_kernel.squeeze() == 1.0)[0][0].item()
+                )
+                new_start = current_start + mask_shift
+
+                nonadv_ids = input_ids[~attack_mask]
+                adv_ids = input_ids[attack_mask]
+                ids = torch.cat(
+                    [
+                        nonadv_ids[:new_start],
+                        adv_ids,
+                        nonadv_ids[new_start:],
+                    ],
+                    dim=0,
+                )
+
+                output_ids.append(ids)
+
+        output_embeds = torch.stack(output_embeds)
+        output_ids = torch.stack(output_ids)
+
+        inputs["inputs_embeds"] = output_embeds
+        inputs["input_ids"] = output_ids
+
+        return inputs

--- a/examples/vision/requirements.txt
+++ b/examples/vision/requirements.txt
@@ -1,0 +1,5 @@
+tokenizers==0.19.1
+transformers==4.43.2
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.4.0
+fire==0.7.0


### PR DESCRIPTION
I attempted to add an example for the LLMart vision for `meta-llama/Llama-3.2-11B-Vision` following basic example.


I successfully converted the processor from the AutoProcessor class into a wrapped tokenizer. Consequently, I am now receiving an `inputs` dictionary that includes both `text_inputs` and `image_inputs`. However, the attack does not progress further due to the following error:
```
torch.cat(): expected a non-empty list of Tensors
File "/home/adarshan/LLMart/src/llmart/model.py", line 98, in _create_parameters
param = torch.nn.Parameter(torch.cat(list(params.values()), dim=0))
File "/home/adarshan/LLMart/src/llmart/model.py", line 52, in __init__
self.param, self.slices = self._create_parameters(attacks)
File "/home/adarshan/LLMart/examples/vision/main.py", line 84, in attack
token_attack = AdversarialAttack(inputs, model.get_input_embeddings()).to(
File "/home/adarshan/LLMart/examples/vision/main.py", line 162, in <module>
fire.Fire(attack)
RuntimeError: torch.cat(): expected a non-empty list of Tensors
```

Please note that due to time constraints and a lack of understanding of the code, I am submitting the partial code as is.
Signed-off-by: Adarsh Anand <adarsh.anand@intel.com>