### PR TITLE
Add Harmbench integration

### DIFF
--- a/src/llmart/attack.py
+++ b/src/llmart/attack.py
@@ -556,10 +556,10 @@ def evaluate(
         loss = F.cross_entropy(logits, targets)
         attack_success = (logits.argmax(-1) == targets).sum()
         attack_count = (targets != -100).sum()
-        attack_success_rate = attack_success / attack_count    
+        attack_success_rate = attack_success / attack_count
 
         log.info(
-                f"{continuation=} {loss=:0.4f} {attack_success_rate=:0.3f}"
+            f"{continuation=} {loss=:0.4f} {attack_success_rate=:0.3f}"
         ) if log else None
 
         # Log prob and rank of targets

--- a/src/llmart/utils.py
+++ b/src/llmart/utils.py
@@ -100,7 +100,8 @@ def early_exit_on_empty(func):
 
     return wrapper
 
-def add_behavior_to_json(behavior_id: int, generation: list, filename: str):
+
+def add_behavior_to_json(behavior_id: int, generation: list, filename: str) -> bool:
     """
     Adds behavior outputs to json file used for output benchmark evaluation
 
@@ -113,25 +114,25 @@ def add_behavior_to_json(behavior_id: int, generation: list, filename: str):
         True
     """
     file_path = Path(filename)
+    # Create File
     if not file_path.exists():
         with open(filename, 'w') as file:
             json.dump({}, file)
 
     with open(filename, 'r+') as file:
+        # Init/Corruption case handling
         try:
             data = json.load(file)
         except json.JSONDecodeError:
             data = dict()
-
+        # Create empty placeholder
         if behavior_id not in data:
             data[f"behavior_id_{behavior_id}"] = []
-
-        # Append each generation to the existing list for the behavior ID
-        # One behavior id could have multiple generations
-        for text in generation:
-            data[f"behavior_id_{behavior_id}"].append({"generation": text})
+        data[f"behavior_id_{behavior_id}"].append({"generation": generation})
 
         # Clear the file content and write the updated data
         file.seek(0)
         json.dump(data, file, indent=4)
         file.truncate()
+
+        return True


### PR DESCRIPTION
**Overview:**
We couldn't run Harmbench due to environmental issues, and the README commands from their repo not working here.
From what I could undertand, the --completions_path is basically a file which consists of the test_case_id and generated_response from the model. 
As per @mariusarvinte  suggestion, we have only implemented this for advbench_dataset. This is currently disabled for any other types of data input. 

**Utils.py**
Added a JSON helper function to keep updating the json file
**Attack.py**
1. Transformed the continuation prompt which has tags + user + assistant responses => Response only from assistant using the LLmart.Transformer class.
2. Enabled JSON logging only for data=advbench 
3. Indexing of JSON id based on subset id as suggested by @mariusarvinte 

**Input command:**
`python -m llmart model=llama3-8b-instruct data=advbench_behavior data.subset=[0,1,2,3] loss=model steps=1`
**Execution Output:**
![harmbench_output](https://github.com/user-attachments/assets/8644ff05-7322-4b6b-83a3-c761eb7f94bb)


Note: The output of JSON is structured exactly in the format of Harmbench evaluation [script ](https://github.com/centerforaisafety/HarmBench/blob/main/evaluate_completions.py)


Fixes #11