### PR TITLE
Fix type errors

### DIFF
--- a/src/llmart/attack.py
+++ b/src/llmart/attack.py
@@ -451,7 +451,7 @@ def make_closure(
         for micro_inputs in data.microbatch(inputs, micro_batch_size=batch_size):
             adv_inputs = attack(micro_inputs)
             if not is_valid_input(adv_inputs["input_ids"]).all():
-                loss = torch.tensor(torch.inf, device=model.device)
+                loss = torch.tensor(torch.inf, device=adv_inputs["input_ids"].device)
                 break
             else:
                 outputs = model(

--- a/src/llmart/optim.py
+++ b/src/llmart/optim.py
@@ -247,7 +247,7 @@ class GreedyCoordinateGradient(Optimizer):
             self._param.data[coord.index, coord.value] = 1.0
         else:
             # Convert values to embeddings and use basic indexing to set embeds
-            embeds = self._embedding(coord.to_tensor(self._embedding.device)[..., 1])
+            embeds = self._embedding(coord.to_tensor(self._param.device)[..., 1])
             for idx, embed in zip(coord.index, embeds):
                 self._param.data[idx].copy_(embed)
 

--- a/src/llmart/tokenizer.py
+++ b/src/llmart/tokenizer.py
@@ -470,9 +470,15 @@ class TaggedTokenizer(PreTrainedTokenizerFast):
         # and any other special token is red
         from colorlog import escape_codes
 
+        if self.additional_special_tokens_ids is None:
+            raise ValueError(
+                "additional_special_tokens_ids is None, please check the tokenizer!"
+            )
+
         colors = {
             token_id: escape_codes.escape_codes["bg_22"]  # dark green
-            if self.convert_ids_to_tokens(token_id) == (BEGIN_TAG_FORMAT % "response")
+            if self.convert_ids_to_tokens(int(token_id))
+            == (BEGIN_TAG_FORMAT % "response")
             else escape_codes.escape_codes["bg_52"]  # dark red
             for token_id in self.additional_special_tokens_ids
         }


### PR DESCRIPTION
Two complaints for accessing `model.device`; replaced with `tensor.device`:
```
LLMart/src/llmart/attack.py:454:55 - error: Argument of type "Tensor | Module" cannot be assigned to parameter "device" of type "DeviceLikeType | None" in function "tensor" (reportArgumentType)

LLMart/src/llmart/optim.py:250:54 - error: Argument of type "Tensor | Module" cannot be assigned to parameter "device" of type "str" in function "to_tensor"
    Type "Tensor | Module" is incompatible with type "str"
      "Module" is incompatible with "str" (reportArgumentType)
```

`token_id` is marked as `str | Unknown`, not sure where this is coming from but fixed by casting to `int`
```
LLMart/src/llmart/tokenizer.py:475:43 - error: Argument of type "str | Unknown" cannot be assigned to parameter "ids" of type "int | List[int]" in function "convert_ids_to_tokens" (reportArgumentType)
```

`tokenizer.additional_special_tokens_ids` could be None, so raising error if it is.

```
LLMart/src/llmart/tokenizer.py:477:29 - error: Object of type "None" cannot be used as iterable value (reportOptionalIterable)
```